### PR TITLE
Fix -Wformat errors with explicit void* -> char* cast.

### DIFF
--- a/sde-drm/drm_connector.cpp
+++ b/sde-drm/drm_connector.cpp
@@ -500,7 +500,7 @@ void DRMConnector::ParseCapabilities(uint64_t blob_id, DRMConnectorInfo *info) {
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
   string line = {};
   const string display_type = "display type=";
   const string panel_name = "panel name=";
@@ -588,7 +588,7 @@ void DRMConnector::ParseModeProperties(uint64_t blob_id, DRMConnectorInfo *info)
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
 
   string line = {};
   const string mode_name = "mode_name=";

--- a/sde-drm/drm_crtc.cpp
+++ b/sde-drm/drm_crtc.cpp
@@ -380,7 +380,7 @@ void DRMCrtc::ParseCapabilities(uint64_t blob_id) {
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
   string line = {};
   string max_blendstages = "max_blendstages=";
   string qseed_type = "qseed_type=";

--- a/sde-drm/drm_plane.cpp
+++ b/sde-drm/drm_plane.cpp
@@ -475,7 +475,7 @@ void DRMPlane::GetTypeInfo(const PropertyMap &prop_map) {
   // like formats etc
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
 
   string line = {};
   string pixel_formats = "pixel_formats=";


### PR DESCRIPTION
hardware/qcom/sm7250/display/sde-drm/drm_plane.cpp:439:12: error: format specifies type 'char *' but the argument has type 'void *' [-Werror,-Wformat]
           blob->data, blob->length);
           ^~~~~~~~~~

hardware/qcom/sm7250/display/sde-drm/drm_connector.cpp:497:12: error: format specifies type 'char *' but the argument has type 'void *' [-Werror,-Wformat]
           blob->data, blob->length);
           ^~~~~~~~~~

hardware/qcom/sm7250/display/sde-drm/drm_connector.cpp:580:12: error: format specifies type 'char *' but the argument has type 'void *' [-Werror,-Wformat]
           blob->data, blob->length);
           ^~~~~~~~~~

hardware/qcom/sm7250/display/sde-drm/drm_crtc.cpp:308:12: error: format specifies type 'char *' but the argument has type 'void *' [-Werror,-Wformat]
           blob->data, blob->length);
           ^~~~~~~~~~

Bug: http://b/155835175
Bug: http://b/169166735
Test: m
Change-Id: Ie9c174aaa38bb9a492b433b27ebafcfe1e1fc115
Merged-In: Ie9c174aaa38bb9a492b433b27ebafcfe1e1fc115
(cherry picked from commit d6c77ce7fae676a501db369ea2c2378f14cda6b2)