### PR TITLE
Avoid Readback buffer support if window_rect feature used

### DIFF
--- a/composer/Android.bp
+++ b/composer/Android.bp
@@ -1,9 +1,28 @@
 composer_srcs = ["*.cpp"]
 
+soong_config_module_type {
+    name: "dolby_vision_cc_defaults",
+    module_type: "cc_defaults",
+    config_namespace: "dolby_vision",
+    bool_variables: ["enabled"],
+    properties: ["cflags"],
+}
+
+dolby_vision_cc_defaults {
+    name: "dolby_vision_defaults",
+    soong_config_variables: {
+        enabled: {
+            cflags: [
+                "-DTARGET_SUPPORTS_DOLBY_VISION",
+            ],
+        },
+    },
+}
+
 cc_binary {
 
     name: "vendor.qti.hardware.display.composer-service",
-    defaults: ["qtidisplay_defaults"],
+    defaults: ["qtidisplay_defaults", "dolby_vision_defaults"],
     sanitize: {
         integer_overflow: true,
     },

--- a/composer/hwc_display.cpp
+++ b/composer/hwc_display.cpp
@@ -1600,22 +1600,18 @@ HWC2::Error HWCDisplay::GetHdrCapabilities(uint32_t *out_num_types, int32_t *out
 
   uint32_t num_types = 0;
   if (fixed_info.hdr_plus_supported) {
-    num_types = UINT32(Hdr::HDR10_PLUS) - 1;
+    num_types = UINT32(Hdr::HDR10_PLUS);
   } else {
-    num_types = UINT32(Hdr::HLG) - 1;
+    num_types = UINT32(Hdr::HLG);
   }
 
-  // We support HDR10, HLG and HDR10_PLUS.
+  // We support DOLBY_VISION, HDR10, HLG and HDR10_PLUS.
   if (out_types == nullptr) {
     *out_num_types = num_types;
   } else {
     uint32_t max_out_types = std::min(*out_num_types, num_types);
     int32_t type = static_cast<int32_t>(Hdr::DOLBY_VISION);
     for (int32_t i = 0; i < max_out_types; i++) {
-      while (type == static_cast<int32_t>(Hdr::DOLBY_VISION) /* Skip list */) {
-        // Skip the type
-        type++;
-      }
       if (type > (num_types + 1)) {
         break;
       }

--- a/composer/hwc_display.cpp
+++ b/composer/hwc_display.cpp
@@ -1600,18 +1600,33 @@ HWC2::Error HWCDisplay::GetHdrCapabilities(uint32_t *out_num_types, int32_t *out
 
   uint32_t num_types = 0;
   if (fixed_info.hdr_plus_supported) {
+#ifdef TARGET_SUPPORTS_DOLBY_VISION
     num_types = UINT32(Hdr::HDR10_PLUS);
   } else {
     num_types = UINT32(Hdr::HLG);
   }
 
   // We support DOLBY_VISION, HDR10, HLG and HDR10_PLUS.
+#else
+    num_types = UINT32(Hdr::HDR10_PLUS) - 1;
+  } else {
+    num_types = UINT32(Hdr::HLG) - 1;
+  }
+
+  // We support HDR10, HLG and HDR10_PLUS.
+#endif /* TARGET_SUPPORTS_DOLBY_VISION */
   if (out_types == nullptr) {
     *out_num_types = num_types;
   } else {
     uint32_t max_out_types = std::min(*out_num_types, num_types);
     int32_t type = static_cast<int32_t>(Hdr::DOLBY_VISION);
     for (int32_t i = 0; i < max_out_types; i++) {
+#ifndef TARGET_SUPPORTS_DOLBY_VISION
+      while (type == static_cast<int32_t>(Hdr::DOLBY_VISION) /* Skip list */) {
+        // Skip the type
+        type++;
+      }
+#endif /* TARGET_SUPPORTS_DOLBY_VISION */
       if (type > (num_types + 1)) {
         break;
       }

--- a/composer/hwc_display_builtin.cpp
+++ b/composer/hwc_display_builtin.cpp
@@ -1824,6 +1824,13 @@ bool HWCDisplayBuiltIn::HasReadBackBufferSupport() {
   DisplayConfigFixedInfo fixed_info = {};
   display_intf_->GetConfig(&fixed_info);
 
+  uint32_t width = UINT32(window_rect_.right + window_rect_.left);
+  uint32_t height = UINT32(window_rect_.bottom + window_rect_.top);
+  if (width > 0 || height > 0) {
+     DLOGE("No ReadBackBuffersupport on window_rect width = %u - height = %u",width,height);
+     return false;
+  }
+
   return fixed_info.readback_supported;
 }
 


### PR DESCRIPTION
When window rect feature is used, Display width, height returned to the client are different than actual panel width, height. This results in drmModeAtomicCommit failures due to WBC and primary panel width, height mismatch.

Change-Id: Ibaca5e3ffc9c0093214eb0cab5c89d4fa0bd0d7e